### PR TITLE
fix: Remove ldd from Dockerfile apt-get install list

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     gnupg \
     strace \
     gdb \
-    ldd \
     file \
     procps \
     libssl-dev \


### PR DESCRIPTION
## Summary
- Fixed Docker build failure by removing `ldd` from the apt-get install list
- `ldd` is not a package but a command that comes with libc-bin

## Changes
- Removed `ldd` from the package installation list in Dockerfile

## Test plan
- [x] Docker build should succeed
- [ ] All other diagnostic tools remain available

🤖 Generated with [Claude Code](https://claude.ai/code)