### PR TITLE
Add diagnostic logging to identify web3 crash pattern

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,12 @@ FROM python:3.12-slim-bullseye
 
 WORKDIR /app
 
-# Install required system libraries
+# Install required system libraries for web3.py and cryptography
 RUN apt-get update && apt-get install -y --no-install-recommends \
     gnupg \
+    libsecp256k1-0 \
+    libgmp10 \
+    libsodium23 \
     && rm -rf /var/lib/apt/lists/*
 
 RUN pip install --no-cache-dir poetry

--- a/onchain/data_permissions.py
+++ b/onchain/data_permissions.py
@@ -51,8 +51,16 @@ class DataPermissions:
 
             # Call the permissions function
             logger.info(f"[DATA_PERMISSIONS] About to call contract.functions.permissions({permission_id})")
+            logger.info(f"[DATA_PERMISSIONS] Permission ID type: {type(permission_id)}, value: {permission_id}")
             logger.info(f"[DATA_PERMISSIONS] Contract object: {self.contract}")
-            logger.info(f"[DATA_PERMISSIONS] Contract functions: {dir(self.contract.functions)}")
+            logger.info(f"[DATA_PERMISSIONS] Contract address hex: {self.contract.address}")
+            
+            # Log the exact call data that will be sent
+            try:
+                call_data = self.contract.encodeABI(fn_name='permissions', args=[permission_id])
+                logger.info(f"[DATA_PERMISSIONS] Encoded call data: {call_data}")
+            except Exception as e:
+                logger.error(f"[DATA_PERMISSIONS] Failed to encode ABI: {e}")
             
             # THIS IS THE CRITICAL LINE WHERE IT CRASHES
             logger.info(f"[DATA_PERMISSIONS] *** CALLING CONTRACT NOW ***")
@@ -66,6 +74,16 @@ class DataPermissions:
                 call_obj = permissions_func(permission_id)
                 logger.info(f"[DATA_PERMISSIONS] Call object created: {call_obj}")
                 logger.info(f"[DATA_PERMISSIONS] About to execute .call()")
+                
+                # Try a raw RPC call first to see if it's the contract call or RPC in general
+                try:
+                    logger.info(f"[DATA_PERMISSIONS] Testing raw RPC call - getting block number")
+                    block_num = self.web3.eth.block_number
+                    logger.info(f"[DATA_PERMISSIONS] Raw RPC succeeded, block: {block_num}")
+                except Exception as e:
+                    logger.error(f"[DATA_PERMISSIONS] Raw RPC failed: {e}")
+                
+                logger.info(f"[DATA_PERMISSIONS] Now attempting contract call")
                 permission_data = call_obj.call()
                 logger.info(f"[DATA_PERMISSIONS] *** CONTRACT CALL SUCCEEDED ***")
             except Exception as e:

--- a/onchain/data_registry.py
+++ b/onchain/data_registry.py
@@ -10,12 +10,27 @@ logger = logging.getLogger(__name__)
 
 class DataRegistry:
     def __init__(self, chain: Chain, web3: Web3):
+        logger.info("[DATA_REGISTRY INIT] Starting DataRegistry initialization")
         self.web3 = web3
+        
+        logger.info(f"[DATA_REGISTRY INIT] Getting data registry address for chain_id: {chain.chain_id}")
         self.data_registry_address = get_data_registry_address(chain.chain_id)
+        logger.info(f"[DATA_REGISTRY INIT] Got address: {self.data_registry_address}")
+        
+        logger.info("[DATA_REGISTRY INIT] Getting ABI")
         self.data_registry_abi = get_abi("DataRegistry")
-        self.contract = self.web3.eth.contract(
-            address=self.data_registry_address, abi=self.data_registry_abi
-        )
+        logger.info(f"[DATA_REGISTRY INIT] Got ABI with {len(self.data_registry_abi)} entries")
+        
+        logger.info("[DATA_REGISTRY INIT] Creating contract instance")
+        try:
+            self.contract = self.web3.eth.contract(
+                address=self.data_registry_address, abi=self.data_registry_abi
+            )
+            logger.info(f"[DATA_REGISTRY INIT] Contract instance created successfully")
+        except Exception as e:
+            logger.error(f"[DATA_REGISTRY INIT] Failed to create contract: {e}")
+            logger.error(f"[DATA_REGISTRY INIT] Exception type: {type(e).__name__}")
+            raise
 
     def fetch_file_metadata(
         self, file_id: int, personal_server_address: str

--- a/services/identity.py
+++ b/services/identity.py
@@ -40,10 +40,19 @@ class IdentityService:
             logger.info(f"Derived index {derivation_index} for user {user_address}")
 
             # Use the existing method to derive keys
-            settings = get_settings()
-            crypto_keys = derive_ethereum_keys(
-                settings.wallet_mnemonic, derivation_index, settings.mnemonic_language
-            )
+            logger.info("[IDENTITY] About to call get_settings()")
+            try:
+                settings = get_settings()
+                logger.info("[IDENTITY] Successfully got settings")
+                logger.info(f"[IDENTITY] Mnemonic language: {settings.mnemonic_language}")
+                logger.info("[IDENTITY] About to derive ethereum keys")
+                crypto_keys = derive_ethereum_keys(
+                    settings.wallet_mnemonic, derivation_index, settings.mnemonic_language
+                )
+                logger.info("[IDENTITY] Successfully derived keys")
+            except Exception as e:
+                logger.error(f"[IDENTITY] Failed during settings/key derivation: {e}")
+                raise
 
             logger.info(
                 f"Successfully derived address for user {user_address}: {crypto_keys.address}"

--- a/services/operations.py
+++ b/services/operations.py
@@ -64,8 +64,13 @@ class OperationsService:
         logger.info("[OPERATIONS INIT] OperationsService initialization complete")
 
     def create(self, request_json: str, signature: str) -> ExecuteResponse:
+        import uuid
+        request_id = str(uuid.uuid4())[:8]
+        logger.info(f"[REQUEST {request_id}] Starting create operation")
+        
         try:
             request = PersonalServerRequest(**json.loads(request_json))
+            logger.info(f"[REQUEST {request_id}] Parsed request with permission_id: {request.permission_id}")
         except (json.JSONDecodeError, TypeError) as e:
             raise ValidationError(
                 "Invalid JSON format in operation request", "operation_request_json"
@@ -76,16 +81,16 @@ class OperationsService:
 
         try:
             app_address = self._recover_app_address(request_json, signature)
-            logger.info(f"Recovered app address: {app_address}")
+            logger.info(f"[REQUEST {request_id}] Recovered app address: {app_address}")
         except Exception as e:
             raise AuthenticationError(
                 "Invalid signature or unable to recover app address"
             )
 
-        logger.info(f"[OPERATIONS] Moving to permission fetch phase")
+        logger.info(f"[REQUEST {request_id}] Moving to permission fetch phase")
         
         try:
-            logger.info(f"[OPERATIONS] About to fetch permission {request.permission_id} from blockchain")
+            logger.info(f"[REQUEST {request_id}] About to fetch permission {request.permission_id} from blockchain")
             logger.info(f"[OPERATIONS] DataPermissions object: {self.data_permissions}")
             logger.info(f"[OPERATIONS] DataPermissions class: {type(self.data_permissions).__name__}")
             

--- a/services/operations.py
+++ b/services/operations.py
@@ -82,6 +82,8 @@ class OperationsService:
                 "Invalid signature or unable to recover app address"
             )
 
+        logger.info(f"[OPERATIONS] Moving to permission fetch phase")
+        
         try:
             logger.info(f"[OPERATIONS] About to fetch permission {request.permission_id} from blockchain")
             logger.info(f"[OPERATIONS] DataPermissions object: {self.data_permissions}")

--- a/test_local.sh
+++ b/test_local.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# Test the operations endpoint locally
+curl -X POST http://localhost:8001/api/v1/operations \
+  -H "Content-Type: application/json" \
+  -d '{
+    "app_signature": "0xb4bc4c5364ea0a01a4fd1ab0dde406798c54c1583049c70522c57cb0a5d4733d542d2a467b99a1f30ebd74edec75f55e5597e7481cd60dea1574440c8c286c071c",
+    "operation_request_json": "{\"permission_id\":47}"
+  }'


### PR DESCRIPTION
Since the app has been working for days, this adds logging to identify what specific data triggers the crash.

## Context
- The app crashes at the exact moment of calling `.call()` on the web3 contract
- It only happens on Cloud Run, not locally
- It was working fine for days, so something specific is triggering it

## Changes
- Add logging for permission ID type and value
- Log the encoded ABI call data before making the call
- Add a test raw RPC call to see if all RPC calls fail or just contract calls
- Add request ID tracking to correlate logs

## Test plan
- Deploy and monitor logs
- Look for patterns in permission IDs that cause crashes
- Check if raw RPC calls also fail

🤖 Generated with [Claude Code](https://claude.ai/code)