### PR TITLE
Update personal server for new smart contract architecture

### DIFF
--- a/domain/entities.py
+++ b/domain/entities.py
@@ -44,9 +44,11 @@ class PermissionData:
     id: int
     grantor: str
     nonce: int
+    grantee_id: int
     grant: str
     signature: bytes
-    is_active: bool
+    start_block: int
+    end_block: int
     file_ids: List[int]
 
 

--- a/onchain/abi.py
+++ b/onchain/abi.py
@@ -3,7 +3,7 @@ Contract ABIs for the data portability personal server.
 Single source of truth for all contract ABIs.
 """
 
-# DataPermissions ABI
+# DataPermissions ABI (updated for DataPortabilityPermissions)
 DATA_PERMISSIONS_ABI = [
     {
         "inputs": [
@@ -16,16 +16,18 @@ DATA_PERMISSIONS_ABI = [
                     {"internalType": "uint256", "name": "id", "type": "uint256"},
                     {"internalType": "address", "name": "grantor", "type": "address"},
                     {"internalType": "uint256", "name": "nonce", "type": "uint256"},
+                    {"internalType": "uint256", "name": "granteeId", "type": "uint256"},
                     {"internalType": "string", "name": "grant", "type": "string"},
                     {"internalType": "bytes", "name": "signature", "type": "bytes"},
-                    {"internalType": "bool", "name": "isActive", "type": "bool"},
+                    {"internalType": "uint256", "name": "startBlock", "type": "uint256"},
+                    {"internalType": "uint256", "name": "endBlock", "type": "uint256"},
                     {
                         "internalType": "uint256[]",
                         "name": "fileIds",
                         "type": "uint256[]",
                     },
                 ],
-                "internalType": "struct IDataPermissions.PermissionInfo",
+                "internalType": "struct IDataPortabilityPermissions.PermissionInfo",
                 "name": "",
                 "type": "tuple",
             }
@@ -76,12 +78,36 @@ DATA_REGISTRY_ABI = [
     },
 ]
 
+# DataPortabilityGrantees ABI
+DATA_PORTABILITY_GRANTEES_ABI = [
+    {
+        "inputs": [{"internalType": "uint256", "name": "granteeId", "type": "uint256"}],
+        "name": "grantees",
+        "outputs": [
+            {
+                "components": [
+                    {"internalType": "address", "name": "owner", "type": "address"},
+                    {"internalType": "address", "name": "granteeAddress", "type": "address"},
+                    {"internalType": "string", "name": "publicKey", "type": "string"},
+                    {"internalType": "uint256[]", "name": "permissionIds", "type": "uint256[]"},
+                ],
+                "internalType": "struct IDataPortabilityGrantees.GranteeInfo",
+                "name": "",
+                "type": "tuple",
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function",
+    }
+]
+
 
 def get_abi(contract_name: str) -> list:
     """Get ABI for a specific contract."""
     abi_map = {
         "DataPermissions": DATA_PERMISSIONS_ABI,
         "DataRegistry": DATA_REGISTRY_ABI,
+        "DataPortabilityGrantees": DATA_PORTABILITY_GRANTEES_ABI,
     }
 
     if contract_name not in abi_map:

--- a/onchain/chain.py
+++ b/onchain/chain.py
@@ -27,14 +27,20 @@ CHAINS = {
 CONTRACTS = {
     "DataPermissions": {
         "addresses": {
-            MOKSHA.chain_id: "0x31fb1D48f6B2265A4cAD516BC39E96a18fb7c8de",
-            MAINNET.chain_id: "0x31fb1D48f6B2265A4cAD516BC39E96a18fb7c8de",
+            MOKSHA.chain_id: "0xD54523048AdD05b4d734aFaE7C68324Ebb7373eF",
+            MAINNET.chain_id: "0xD54523048AdD05b4d734aFaE7C68324Ebb7373eF",
         },
     },
     "DataRegistry": {
         "addresses": {
             MOKSHA.chain_id: "0x8C8788f98385F6ba1adD4234e551ABba0f82Cb7C",
             MAINNET.chain_id: "0x8C8788f98385F6ba1adD4234e551ABba0f82Cb7C",
+        },
+    },
+    "DataPortabilityGrantees": {
+        "addresses": {
+            MOKSHA.chain_id: "0x8325C0A0948483EdA023A1A2Fd895e62C5131234",
+            MAINNET.chain_id: "0x8325C0A0948483EdA023A1A2Fd895e62C5131234",
         },
     },
 }
@@ -71,3 +77,8 @@ def get_data_permissions_address(chain_id: int = MOKSHA.chain_id) -> str:
 def get_data_registry_address(chain_id: int = MOKSHA.chain_id) -> str:
     """Get DataRegistry contract address."""
     return get_contract_address(chain_id, "DataRegistry")
+
+
+def get_data_portability_grantees_address(chain_id: int = MOKSHA.chain_id) -> str:
+    """Get DataPortabilityGrantees contract address."""
+    return get_contract_address(chain_id, "DataPortabilityGrantees")

--- a/onchain/data_permissions.py
+++ b/onchain/data_permissions.py
@@ -41,15 +41,17 @@ class DataPermissions:
                 id=permission_data[0],
                 grantor=permission_data[1],
                 nonce=permission_data[2],
-                grant=permission_data[3],
-                signature=permission_data[4],
-                is_active=permission_data[5],
-                file_ids=permission_data[6],
+                grantee_id=permission_data[3],
+                grant=permission_data[4],
+                signature=permission_data[5],
+                start_block=permission_data[6],
+                end_block=permission_data[7],
+                file_ids=permission_data[8],
             )
 
             # Log the parsed permission data with contract details
             logger.info(f"[BLOCKCHAIN] Parsed permission data: {result}")
-            logger.info(f"[BLOCKCHAIN] Permission {permission_id} - Grantor: {result.grantor}, Active: {result.is_active}, Files: {len(result.file_ids)}")
+            logger.info(f"[BLOCKCHAIN] Permission {permission_id} - Grantor: {result.grantor}, GranteeId: {result.grantee_id}, Files: {len(result.file_ids)}")
 
             return result
 

--- a/onchain/data_portability_grantees.py
+++ b/onchain/data_portability_grantees.py
@@ -1,0 +1,61 @@
+"""
+DataPortabilityGrantees contract interface for the personal server.
+"""
+
+import logging
+from typing import Optional, Dict, Any
+from web3 import AsyncWeb3
+
+from .chain import Chain, get_data_portability_grantees_address
+from .abi import get_abi
+
+logger = logging.getLogger(__name__)
+
+
+class DataPortabilityGrantees:
+    """Interface for the DataPortabilityGrantees smart contract."""
+    
+    def __init__(self, chain: Chain, web3: AsyncWeb3):
+        self.chain = chain
+        self.web3 = web3
+        
+        self.contract_address = get_data_portability_grantees_address(chain.chain_id)
+        self.contract_abi = get_abi("DataPortabilityGrantees")
+        
+        self.contract = self.web3.eth.contract(
+            address=self.contract_address, abi=self.contract_abi
+        )
+    
+    async def get_grantee_info(self, grantee_id: int) -> Optional[Dict[str, Any]]:
+        """Fetch grantee info from the DataPortabilityGrantees contract.
+        
+        Args:
+            grantee_id: The ID of the grantee to fetch
+            
+        Returns:
+            Dict containing grantee information or None if not found
+        """
+        try:
+            logger.info(f"[BLOCKCHAIN] Fetching info for granteeId {grantee_id}")
+            logger.info(f"[BLOCKCHAIN] Contract address: {self.contract_address}, Chain: {self.chain.chain_id}")
+            
+            # Call the grantees function on the contract
+            grantee_data = await self.contract.functions.grantees(grantee_id).call()
+            
+            # The contract returns a tuple: (owner, granteeAddress, publicKey, permissionIds)
+            result = {
+                "owner": grantee_data[0],
+                "granteeAddress": grantee_data[1], 
+                "publicKey": grantee_data[2],
+                "permissionIds": grantee_data[3],
+            }
+            
+            logger.info(f"[BLOCKCHAIN] Successfully fetched grantee info: owner={result['owner']}, address={result['granteeAddress']}")
+            
+            return result
+            
+        except Exception as e:
+            logger.error(f"[BLOCKCHAIN] Failed to fetch info for granteeId {grantee_id}: {e}")
+            logger.error(f"[BLOCKCHAIN] Contract address: {self.contract_address}, Chain: {self.chain.chain_id}")
+            logger.error(f"[BLOCKCHAIN] Exception type: {type(e).__name__}")
+            return None

--- a/tests/test_moksha.py
+++ b/tests/test_moksha.py
@@ -346,11 +346,19 @@ async def test_real_personal_server_flow():
             id=permission_id,
             grantor=user_address,
             nonce=1,
+            grantee_id=1,  # New field
             grant="ipfs://QmTestGrantData",  # Use a non-existent grant URL
             signature=b"test_signature",
-            is_active=True,
+            start_block=1000,  # New field
+            end_block=2000,  # New field
             file_ids=[999],
         ), new_callable=AsyncMock),
+        patch("onchain.data_portability_grantees.DataPortabilityGrantees.get_grantee_info", return_value={
+            "owner": user_address,
+            "granteeAddress": "0xf0ebD65BEaDacD191dc96D8EC69bbA4ABCf621D4",
+            "publicKey": "test_public_key",
+            "permissionIds": [permission_id],
+        }, new_callable=AsyncMock),
         patch("services.operations.fetch_raw_grant_file", return_value={
             "grantee": "0xf0ebD65BEaDacD191dc96D8EC69bbA4ABCf621D4",
             "operation": "llm_inference",
@@ -374,7 +382,7 @@ async def test_real_personal_server_flow():
 
         mock_compute = Mock()
         mock_compute.execute = Mock(return_value="LLM OUTPUT: " + test_file_content)
-        operations_service = OperationsService(mock_compute)
+        operations_service = OperationsService(mock_compute, MOKSHA)
         output = await operations_service.create(request_json, signature.signature)
         print(f"✅ Server.execute output: {output}")
         assert output == "LLM OUTPUT: " + test_file_content


### PR DESCRIPTION
## Summary
- Updated personal server to be compatible with new DataPortability smart contracts
- Added support for granteeId-based permission validation
- Updated all contract interfaces and test mocks

## Changes
- Added DataPortabilityGrantees contract addresses and ABI
- Updated PermissionData entity to include granteeId, startBlock, and endBlock fields
- Created DataPortabilityGrantees contract wrapper class for granteeId resolution
- Modified operations service to resolve granteeId to address before validation
- Updated test mocks to work with new permission structure

## Test Plan
- [x] Updated unit tests to include new permission fields
- [x] Added mocks for DataPortabilityGrantees contract calls
- [x] Verified all Python files compile without syntax errors
- [ ] Manual testing with deployed contracts on testnet

## Context
This PR implements the changes needed to support the new smart contract architecture as described in the vana-sdk PR. The key change is that permissions now use numeric granteeIds instead of direct addresses, requiring the server to resolve these IDs through the DataPortabilityGrantees contract.

🤖 Generated with [Claude Code](https://claude.ai/code)