### PR TITLE
feat: Update DataPermissions structure and ABI

### DIFF
--- a/domain/entities.py
+++ b/domain/entities.py
@@ -44,9 +44,10 @@ class PermissionData:
     id: int
     grantor: str
     nonce: int
+    grantee_id: int
     grant: str
-    signature: bytes
-    is_active: bool
+    start_block: int
+    end_block: int
     file_ids: List[int]
 
 

--- a/grants/schema/grantFile.schema.json
+++ b/grants/schema/grantFile.schema.json
@@ -24,6 +24,13 @@
       "type": "integer",
       "minimum": 0,
       "description": "Optional Unix timestamp when grant expires (seconds since epoch per POSIX.1-2008)"
+    },
+    "files": {
+      "type": "array",
+      "items": {
+        "type": "integer"
+      },
+      "description": "Optional array of file IDs associated with this grant"
     }
   },
   "additionalProperties": false,

--- a/onchain/abi.py
+++ b/onchain/abi.py
@@ -4,36 +4,67 @@ Single source of truth for all contract ABIs.
 """
 
 # DataPermissions ABI
-DATA_PERMISSIONS_ABI = [
-    {
-        "inputs": [
-            {"internalType": "uint256", "name": "permissionId", "type": "uint256"}
+DATA_PERMISSIONS_ABI = [{
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "permissionId",
+        "type": "uint256"
+      }
+    ],
+    "name": "permissions",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "id",
+            "type": "uint256"
+          },
+          {
+            "internalType": "address",
+            "name": "grantor",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "nonce",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "granteeId",
+            "type": "uint256"
+          },
+          {
+            "internalType": "string",
+            "name": "grant",
+            "type": "string"
+          },
+          {
+            "internalType": "uint256",
+            "name": "startBlock",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "endBlock",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256[]",
+            "name": "fileIds",
+            "type": "uint256[]"
+          }
         ],
-        "name": "permissions",
-        "outputs": [
-            {
-                "components": [
-                    {"internalType": "uint256", "name": "id", "type": "uint256"},
-                    {"internalType": "address", "name": "grantor", "type": "address"},
-                    {"internalType": "uint256", "name": "nonce", "type": "uint256"},
-                    {"internalType": "string", "name": "grant", "type": "string"},
-                    {"internalType": "bytes", "name": "signature", "type": "bytes"},
-                    {"internalType": "bool", "name": "isActive", "type": "bool"},
-                    {
-                        "internalType": "uint256[]",
-                        "name": "fileIds",
-                        "type": "uint256[]",
-                    },
-                ],
-                "internalType": "struct IDataPermissions.PermissionInfo",
-                "name": "",
-                "type": "tuple",
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function",
-    }
-]
+        "internalType": "struct IDataPortabilityPermissions.PermissionInfo",
+        "name": "",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }]
 
 # DataRegistry ABI
 DATA_REGISTRY_ABI = [

--- a/onchain/chain.py
+++ b/onchain/chain.py
@@ -27,8 +27,8 @@ CHAINS = {
 CONTRACTS = {
     "DataPermissions": {
         "addresses": {
-            MOKSHA.chain_id: "0x31fb1D48f6B2265A4cAD516BC39E96a18fb7c8de",
-            MAINNET.chain_id: "0x31fb1D48f6B2265A4cAD516BC39E96a18fb7c8de",
+            MOKSHA.chain_id: "0xD54523048AdD05b4d734aFaE7C68324Ebb7373eF",
+            MAINNET.chain_id: "0xD54523048AdD05b4d734aFaE7C68324Ebb7373eF",
         },
     },
     "DataRegistry": {

--- a/onchain/data_permissions.py
+++ b/onchain/data_permissions.py
@@ -41,15 +41,16 @@ class DataPermissions:
                 id=permission_data[0],
                 grantor=permission_data[1],
                 nonce=permission_data[2],
-                grant=permission_data[3],
-                signature=permission_data[4],
-                is_active=permission_data[5],
-                file_ids=permission_data[6],
+                grantee_id=permission_data[3],
+                grant=permission_data[4],
+                start_block=permission_data[5],
+                end_block=permission_data[6],
+                file_ids=permission_data[7],
             )
 
             # Log the parsed permission data with contract details
             logger.info(f"[BLOCKCHAIN] Parsed permission data: {result}")
-            logger.info(f"[BLOCKCHAIN] Permission {permission_id} - Grantor: {result.grantor}, Active: {result.is_active}, Files: {len(result.file_ids)}")
+            logger.info(f"[BLOCKCHAIN] Permission {permission_id} - Grantor: {result.grantor}, Grantee ID: {result.grantee_id}, Blocks: {result.start_block}-{result.end_block}, Files: {len(result.file_ids)}")
 
             return result
 

--- a/tests/test_mocks.py
+++ b/tests/test_mocks.py
@@ -94,9 +94,10 @@ async def test_personal_server(
             id=6,
             grantor="0x1234567890123456789012345678901234567890",
             nonce=1,
+            grantee_id=123,
             grant="ipfs://QmTestGrantData",
-            signature=b"test_signature",
-            is_active=True,
+            start_block=1000,
+            end_block=2000,
             file_ids=[999],
         )
         mock_fetch_permission.return_value = mock_permission_data


### PR DESCRIPTION
- Added `grantee_id`, `start_block`, and `end_block` fields to `PermissionData`.
- Updated the `DATA_PERMISSIONS_ABI` to reflect the new structure.
- Modified the `DataPermissions` class to handle the new fields.
- Adjusted logging to include `grantee_id` and block range in permission data output.
- Updated test mocks to align with the new permission structure.