### PR TITLE
Return uncompressed public key

### DIFF
--- a/utils/derive_ethereum_keys.py
+++ b/utils/derive_ethereum_keys.py
@@ -6,7 +6,7 @@ Based on the original crypto_service.py but stripped down for the key derivation
 import logging
 from typing import NamedTuple
 from eth_account import Account
-import eth_keys as keys
+import eth_keys.datatypes as keys
 
 logger = logging.getLogger(__name__)
 

--- a/utils/derive_ethereum_keys.py
+++ b/utils/derive_ethereum_keys.py
@@ -6,6 +6,7 @@ Based on the original crypto_service.py but stripped down for the key derivation
 import logging
 from typing import NamedTuple
 from eth_account import Account
+import eth_keys as keys
 
 logger = logging.getLogger(__name__)
 
@@ -61,7 +62,9 @@ def derive_ethereum_keys(
         acct = Account.from_mnemonic(mnemonic, account_path=derivation_path)
 
         private_key_hex = acct.key.hex()
-        public_key_hex = acct._key_obj.public_key.to_hex()
+        # Convert to eth_keys PublicKey to get uncompressed format (130 chars: 0x + 128 hex chars)
+        public_key_bytes = acct._key_obj.public_key.to_bytes()
+        public_key_hex = keys.PublicKey(public_key_bytes).to_hex()
         address = acct.address
 
         return CryptoKeys(


### PR DESCRIPTION
## Issue

The `eth_account` library's `to_hex()` method **defaults to compressed format**.

## What Happens During Compression

```
Input:  Uncompressed public key (65 bytes)
        ↓
to_hex(): Converts to compressed format (33 bytes)
        ↓
Output:  66-character hex string starting with 0x02 or 0x03
```

## The Problem This Creates

The Vana SDK has a **cryptographic requirement** for uncompressed keys:

- **Expected**: Uncompressed keys (130 chars: `0x04...`)
- **Received**: Compressed keys (66 chars: `0x02...` or `0x03...`)
- **Result**: "public key length is invalid" error

## Our Solution

We work around this by extracting the raw uncompressed bytes first:

```python
# Get raw uncompressed bytes (bypasses compression)
public_key_bytes = acct._key_obj.public_key.to_bytes()

# Convert to hex while preserving uncompressed format
public_key_hex = keys.PublicKey(public_key_bytes).to_hex()
```

This ensures the Vana SDK receives the uncompressed format it requires for proper encryption functionality.