### PR TITLE
fix: Ensure Ethereum public key uses SEC1 uncompressed format

### DIFF
--- a/api/schemas.py
+++ b/api/schemas.py
@@ -8,8 +8,11 @@ def validate_ethereum_address(value: str) -> str:
     return value
 
 def validate_public_key(value: str) -> str:
-    if not re.match(r'^0x[a-fA-F0-9]{128}$', value):
-        raise ValueError('Invalid public key format')
+    # Ethereum public keys can be:
+    # - Uncompressed: 65 bytes (130 hex chars including 0x) - starts with 0x04
+    # - Compressed: 33 bytes (66 hex chars including 0x) - starts with 0x02 or 0x03
+    if not re.match(r'^0x[a-fA-F0-9]{64}$|^0x[a-fA-F0-9]{130}$', value):
+        raise ValueError('Invalid public key format - must be exactly 64 or 130 hex characters')
     return value
 
 EthereumAddress = Annotated[str, BeforeValidator(validate_ethereum_address)]

--- a/utils/derive_ethereum_keys.py
+++ b/utils/derive_ethereum_keys.py
@@ -33,6 +33,9 @@ def derive_ethereum_keys(
 ) -> CryptoKeys:
     """
     Derive Ethereum keys for DLP using BIP44 standard.
+    
+    Returns public key in SEC1 uncompressed format (65 bytes with 0x04 prefix)
+    for compatibility with Vana SDK.
 
     Args:
         mnemonic: BIP39 mnemonic phrase
@@ -60,8 +63,14 @@ def derive_ethereum_keys(
         # Generate account from mnemonic and derivation path
         acct = Account.from_mnemonic(mnemonic, account_path=derivation_path)
 
-        private_key_hex = acct.key.hex()
-        public_key_hex = acct._key_obj.public_key.to_hex()
+        # Ensure private key has 0x prefix for consistency
+        private_key_hex = "0x" + acct.key.hex()
+        
+        # Get uncompressed SEC1 format (65 bytes with 0x04 prefix)
+        # This is what Vana SDK expects
+        public_key_raw = acct._key_obj.public_key.to_bytes()
+        public_key_hex = "0x04" + public_key_raw.hex()
+        
         address = acct.address
 
         return CryptoKeys(


### PR DESCRIPTION
## Summary
- Update public key format to SEC1 uncompressed (65 bytes with 0x04 prefix)
- Add 0x prefix to private key for consistency
- Required for compatibility with Vana SDK

🤖 Generated with [Claude Code](https://claude.ai/code)